### PR TITLE
fix(backend): resolve requirements.txt build conflict from aiohttp bump

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
 aiohttp==3.13.4
-aiosignal==1.3.2
+aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.7.0
 async-timeout==5.0.1
@@ -30,7 +30,7 @@ googleapis-common-protos==1.66.0
 greenlet==3.1.1
 gunicorn==23.0.0
 h11==0.16.0
-httpcore==1.0.7
+httpcore==1.0.9
 httplib2==0.22.0
 httpx==0.28.1
 idna==3.15


### PR DESCRIPTION
## Problem
A dependabot bump to `aiohttp==3.13.4` left several transitive pins too low, so `backend/requirements.txt` no longer resolves — `pip install` / `docker build` fails with `ResolutionImpossible`. master was unbuildable.

## Fix
Minimal version bumps to satisfy the new floors:
- `aiosignal` 1.3.2 → 1.4.0 (aiohttp needs `>=1.4.0`)
- `aiohappyeyeballs` 2.4.4 → 2.6.1 (aiohttp needs `>=2.5.0`)
- `httpcore` 1.0.7 → 1.0.9 (accepts `h11==0.16.0`; `httpx==0.28.1` accepts any `httpcore 1.x`)

## Verification
- `docker build` of `backend/Dockerfile` now succeeds and the image was deployed to the cluster (`meal-finder-api` healthy, HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sachiniyer/meal-finder/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->